### PR TITLE
Skr2 sd

### DIFF
--- a/Marlin/Prusa_SKR_Configuration.h
+++ b/Marlin/Prusa_SKR_Configuration.h
@@ -238,6 +238,21 @@
  */
 #define PRUSA_SKR_LCD_LANGUAGE 1
 
+/**
+ * SKR 2 Flash Drive Support
+ * 
+ * Use LCD/onboard SD by default:
+ * 
+ * Multi-volume is expiremental, and is not stable.  At this point, Multi-volume only supports
+ * the onboard SD card slot, and does NOT have an option for using SD cards mounted to LCDs.
+ * 
+ * Options:  1: Use SD Card standalone
+ *           2: Use Flash Drive (built into controller board)
+ *           3: Use SD and Flash Drive (Expiremental!!)
+ */
+ 
+ #define PRUSA_SKR_SD_FLASH_DRIVE 1
+
 //===========================================================================
 //================================ NeoPixels ================================
 //===========================================================================

--- a/Marlin/Prusa_SKR_Configuration.h
+++ b/Marlin/Prusa_SKR_Configuration.h
@@ -59,7 +59,7 @@
  *           3: BigTreeTech BTT002 1.0     (STM32F407VGT6)
  *           4: BigTreeTech SKR 2.0 Rev. B (STM32F407VGT6)
  */
-#define PRUSA_SKR_MOTHERBOARD 1
+#define PRUSA_SKR_MOTHERBOARD 4
 
 //===========================================================================
 //============================= Stepper Motors ==============================

--- a/Marlin/src/inc/Prusa_SKR_Conditionals.h
+++ b/Marlin/src/inc/Prusa_SKR_Conditionals.h
@@ -587,6 +587,42 @@
   #define LCD_LANGUAGE vi
 #endif
 
+/**
+ * SKR 2 Flash Drive Support
+ * 
+ * Use LCD/onboard SD by default:
+ * 
+ * Multi-volume is expiremental, and is not stable.  At this point, Multi-volume only supports
+ * the onboard SD card slot, and does NOT have an option for using SD cards mounted to LCDs.
+ * 
+ * Options:  1: Use SD Card standalone
+ *           2: Use Flash Drive (built into controller board)
+ *           3: Use SD and Flash Drive (Expiremental!!)
+ */
+
+#if !defined(PRUSA_SKR_SD_FLASH_DRIVE) || (PRUSA_SKR_SD_FLASH_DRIVE < 1 || PRUSA_SKR_SD_FLASH_DRIVE > 3)
+  #error "PRUSA_SKR_SD_FLASH_DRIVE is invalid or not defined."
+#elif PRUSA_SKR_SD_FLASH_DRIVE != 1 && PRUSA_SKR_MOTHERBOARD != 4
+  #error "USB Flash Drive is only supported on the SKR 2."
+#elif PRUSA_SKR_SD_FLASH_DRIVE == 1
+  #ifdef USB_FLASH_DRIVE_SUPPORT
+    #undef USB_FLASH_DRIVE_SUPPORT
+  #endif
+#elif PRUSA_SKR_SD_FLASH_DRIVE == 2 || PRUSA_SKR_SD_FLASH_DRIVE == 3 
+  #define USB_FLASH_DRIVE_SUPPORT
+  #define USE_OTG_USB_HOST
+#endif
+
+#if PRUSA_SKR_SD_FLASH_DRIVE == 3
+  #define MULTI_VOLUME
+    #if ENABLED(MULTI_VOLUME)
+      #define VOLUME_SD_ONBOARD
+      #define VOLUME_USB_FLASH_DRIVE
+      #define DEFAULT_VOLUME SV_SD_ONBOARD
+      #define DEFAULT_SHARED_VOLUME SV_USB_FLASH_DRIVE
+    #endif
+#endif
+
 //===========================================================================
 //================================ NeoPixels ================================
 //===========================================================================

--- a/Marlin/src/inc/Prusa_SKR_Conditionals.h
+++ b/Marlin/src/inc/Prusa_SKR_Conditionals.h
@@ -102,9 +102,9 @@
     #define MOTHERBOARD BOARD_BTT_SKR_V2_0_REV_B
     #define SERIAL_PORT 1
 
-    // Flash Drive Support
-    #define USB_FLASH_DRIVE_SUPPORT
-    #define USE_OTG_USB_HOST
+    // Flash Drive Support - THIS DISABLES LCD SD CARD
+    // #define USB_FLASH_DRIVE_SUPPORT
+    // #define USE_OTG_USB_HOST
 
     // Multi-Volume Support
     //#define MULTI_VOLUME


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

I was working with Clanzi#4273 on the Marlin Discord today, and they were having issues accessing their SD card on an SKR2.  Through some troubleshooting, it appears that anytime the SKR2 is chosen, it defaults to using the USB flash drive, which is not the desired behavior for all people.

This PR changes the default behavior to use standard SD card settings, while adding options to use the USB Flash Drive and Multivolume support.

```c
/**
 * SKR 2 Flash Drive Support
 * 
 * Use LCD/onboard SD by default:
 * 
 * Multi-volume is expiremental, and is not stable.  At this point, Multi-volume only supports
 * the onboard SD card slot, and does NOT have an option for using SD cards mounted to LCDs.
 * 
 * Options:  1: Use SD Card standalone
 *           2: Use Flash Drive (built into controller board)
 *           3: Use SD and Flash Drive (Expiremental!!)
 */
```

This moves the `USB_FLASH_DRIVE_SUPPORT` and `MULTI_VOLUME` section from the MOTHERBOARD section to the LCD section.  It throws an error when either is enabled on a board that is not the SKR 2, and handles switching between the different options.

- Option 1 specifically disables `USB_FLASH_DRIVE_SUPPORT`
- Option 2 Enables `USB_FLASH_DRIVE_SUPPORT` and `USE_OTG_USB_HOST` required to use a USB flash drive
- Option 3 Enables `USB_FLASH_DRIVE_SUPPORT` and `USE_OTG_USB_HOST` as above, but also enables `MULTI_VOLUME` with the default settings.

At this time, it is unclear if the code supports changing the primary/secondary volumes, so this does not attempt to do so.  Also, it appears that Multi-volume only supports the onboard SD card, not one mounted to the LCD.  These are not related to this PR or this fork, but are overall limitations.



### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Requires SKR 2 Rev B.

The overall fix (`#undef USB_FLASH_DRIVE_SUPPORT`) was tested with an LCD attached on Clanzi's machine.

### Benefits

<!-- What does this PR fix or improve? -->

SKR 2 users can now select which media device they want to use.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

I tested with all 3 `PRUSA_SKR_SD_FLASH_DRIVE` options with the Motherboard set to 4.  The error come up as expected for changing the motherboard away from the SKR2.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

I can't open an issue since this is a fork so here's a PR.
